### PR TITLE
Add minimal Go hexagonal demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# test-codex
+# Hexagonal Demo
+
+This repository contains a small demonstration of a Go project organised using
+[hexagonal architecture](https://alistair.cockburn.us/hexagonal-architecture/).
+
+The core business logic is defined in the `internal` package and accessed via
+interfaces (ports). Adapters expose the behaviour to the outside world.
+
+## Running the server
+
+```
+go run ./cmd/server
+```
+
+Then open `http://localhost:8080?name=Codex` in your browser to see the
+response.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	httpadapter "hexademo/internal/adapter/http"
+	"hexademo/internal/service"
+)
+
+func main() {
+	greeter := service.NewGreetingService()
+	handler := httpadapter.NewHandler(greeter)
+
+	log.Println("starting server on :8080")
+	if err := http.ListenAndServe(":8080", handler); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module hexademo
+
+go 1.23.8

--- a/internal/adapter/http/handler.go
+++ b/internal/adapter/http/handler.go
@@ -1,0 +1,21 @@
+package http
+
+import (
+	"hexademo/internal/domain"
+	"net/http"
+)
+
+// Handler bridges HTTP requests to the Greeter domain.
+type Handler struct {
+	greeter domain.Greeter
+}
+
+func NewHandler(g domain.Greeter) *Handler {
+	return &Handler{greeter: g}
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get("name")
+	greeting := h.greeter.Greet(name)
+	_, _ = w.Write([]byte(greeting))
+}

--- a/internal/domain/greeting.go
+++ b/internal/domain/greeting.go
@@ -1,0 +1,6 @@
+package domain
+
+// Greeter defines the primary port for greeting someone.
+type Greeter interface {
+	Greet(name string) string
+}

--- a/internal/service/greeting_service.go
+++ b/internal/service/greeting_service.go
@@ -1,0 +1,19 @@
+package service
+
+import "hexademo/internal/domain"
+
+// GreetingService is the default implementation of the Greeter port.
+type GreetingService struct{}
+
+func NewGreetingService() *GreetingService {
+	return &GreetingService{}
+}
+
+func (s *GreetingService) Greet(name string) string {
+	if name == "" {
+		name = "World"
+	}
+	return "Hello, " + name + "!"
+}
+
+var _ domain.Greeter = (*GreetingService)(nil)


### PR DESCRIPTION
## Summary
- initialize Go module
- implement a tiny hexagonal architecture demo with HTTP server
- explain usage in README

## Testing
- `go build ./...`
- `go test ./...`